### PR TITLE
chore: run on ubuntu 24.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ build/
 target/
 javadoc/
 dist/
+release/
+lib/
 
 # Eclipse/VSCode stuff
 .classpath

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# -------------------------------------------------------------------------
+# STAGE 1: BUILD - Builds the application and creates the single 'fat' JAR.
+# -------------------------------------------------------------------------
+FROM maven:3-jdk-13 AS build
+
+WORKDIR /app
+
+# Copy the pom.xml first to leverage Docker layer caching
+COPY pom.xml .
+
+# Copy source code and build the JAR
+COPY src /app/src
+RUN mvn clean package -DskipTests
+
+# -------------------------------------------------------------------------
+# STAGE 2: RUNTIME - Sets up the minimal environment for the GUI application.
+# -------------------------------------------------------------------------
+FROM adoptopenjdk/openjdk13:ubi
+
+# Install necessary X11 dependencies for GUI rendering (libXext, libXrender, libXtst)
+RUN yum install -y libXext libXrender libXtst
+
+# Set the primary working directory
+WORKDIR /app
+
+# Create the specific directory needed for project files and 
+# dynamically compiled Java Block classes (as specified in the Makefile mount).
+RUN mkdir -p /app/projects/tmp
+
+# Copy the final application JAR from the build stage
+COPY --from=build /app/target/app.jar /app/app.jar
+
+# Define the command to run the application.
+# -cp (classpath) includes app.jar AND the temporary directory (/app/projects/tmp)
+# to fix the ClassNotFoundException for dynamically compiled code (tmpJav...).
+# This entrypoint is crucial for dynamic class loading in the complex environment.
+ENTRYPOINT ["java", "-cp", "app.jar:/app/projects/tmp", "ch.technokrat.gecko.GeckoSim"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,7 @@
 FROM maven:3-jdk-13 AS build
 
 WORKDIR /app
-
-# Copy the pom.xml first to leverage Docker layer caching
 COPY pom.xml .
-
-# Copy source code and build the JAR
 COPY src /app/src
 RUN mvn clean package -DskipTests
 
@@ -17,21 +13,19 @@ RUN mvn clean package -DskipTests
 # -------------------------------------------------------------------------
 FROM adoptopenjdk/openjdk13:ubi
 
-# Install necessary X11 dependencies for GUI rendering (libXext, libXrender, libXtst)
-RUN yum install -y libXext libXrender libXtst
+# Install necessary X11 dependencies using YUM (the package manager for UBI)
+# Note: openjdk13 is already included in the base image.
+RUN yum install -y libXext libXrender libXtst && \
+    yum clean all
 
 # Set the primary working directory
 WORKDIR /app
 
-# Create the specific directory needed for project files and 
-# dynamically compiled Java Block classes (as specified in the Makefile mount).
+# Create the specific directory needed for project files and compiled classes.
 RUN mkdir -p /app/projects/tmp
 
 # Copy the final application JAR from the build stage
 COPY --from=build /app/target/app.jar /app/app.jar
 
 # Define the command to run the application.
-# -cp (classpath) includes app.jar AND the temporary directory (/app/projects/tmp)
-# to fix the ClassNotFoundException for dynamically compiled code (tmpJav...).
-# This entrypoint is crucial for dynamic class loading in the complex environment.
 ENTRYPOINT ["java", "-cp", "app.jar:/app/projects/tmp", "ch.technokrat.gecko.GeckoSim"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+# --- Configuration Variables ---
+IMAGE_NAME       := gecko-image
+IMAGE_TAG        := 1.0
+CONTAINER_NAME   := gecko-app
+# Path on the host machine where circuit projects will be stored
+HOST_PROJECT_DIR := ./my_circuit_projects
+# Internal path inside the container for projects (used for the volume mount)
+CONTAINER_PROJECT_DIR := /app/projects
+
+# Phony targets are targets that do not correspond to an actual file.
+.PHONY: build run stop export clean ls help
+
+# Default target
+all: build
+
+# --- Docker Targets ---
+
+build:
+	@echo "🏗️ Building Docker image: $(IMAGE_NAME):$(IMAGE_TAG)..."
+	@docker build -t $(IMAGE_NAME):$(IMAGE_TAG) .
+
+run:
+	@mkdir -p $(HOST_PROJECT_DIR)
+	@echo "🖥️ Allowing Docker to connect to X display..."
+	@xhost +local: > /dev/null
+	@echo "🚀 Running GUI application as container: $(CONTAINER_NAME)..."
+	@docker run --rm \
+		--name $(CONTAINER_NAME) \
+		-e DISPLAY=$(DISPLAY) \
+		-e JAVA_TOOL_OPTIONS="-Djava.io.tmpdir=$(CONTAINER_PROJECT_DIR)/tmp" \
+		-v /tmp/.X11-unix:/tmp/.X11-unix \
+		-v "$(PWD)/$(HOST_PROJECT_DIR):$(CONTAINER_PROJECT_DIR):z" \
+		$(IMAGE_NAME):$(IMAGE_TAG)
+	@echo "🔒 Restoring X display permissions..."
+	@xhost -local: > /dev/null
+
+stop:
+	@echo "🛑 Stopping container: $(CONTAINER_NAME)..."
+	@docker stop $(CONTAINER_NAME) || true
+
+export:
+	@echo "📦 Exporting build artifacts to ./dist..."
+	@DOCKER_BUILDKIT=1 docker build --target build --output type=local,dest=./dist .
+
+ls:
+	@echo "--- 📂 Listing files in $(CONTAINER_PROJECT_DIR) (inside container $(CONTAINER_NAME)) ---"
+	@docker exec $(CONTAINER_NAME) ls -al $(CONTAINER_PROJECT_DIR) || \
+		(echo "Error: Container $(CONTAINER_NAME) not found or not running." && exit 1)
+
+clean:
+	@echo "🗑️ Removing Docker image: $(IMAGE_NAME):$(IMAGE_TAG)..."
+	@docker rmi $(IMAGE_NAME):$(IMAGE_TAG) 2>/dev/null || echo "Image not found, skipping removal."
+	@rm -rf dist target
+
+help:
+	@echo "Usage: make <target>"
+	@echo ""
+	@echo "Targets:"
+	@echo "  build    : Builds the Docker image ($(IMAGE_NAME):$(IMAGE_TAG))."
+	@echo "  run      : Runs the container with X-server access and volume mount."
+	@echo "  stop     : Stops the running container ($(CONTAINER_NAME))."
+	@echo "  export   : Exports build artifacts from a multi-stage build to ./dist."
+	@echo "  ls       : Lists contents of the project directory inside the running container."
+	@echo "  clean    : Removes the local Docker image."

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,20 @@ all: build
 
 # --- Docker Targets ---
 
+install:
+	@echo "⚙️ Installing system dependencies (GUI libs & Java)..."
+	@sudo apt update
+	@sudo apt install -y libxext6 libxrender1 libxtst6 openjdk-17-jdk
+	@echo "⬇️ Downloading Nashorn & its ASM dependencies..."
+	@mkdir -p ./lib
+	@curl -L -o ./lib/nashorn-core.jar https://repo.maven.apache.org/maven2/org/openjdk/nashorn/nashorn-core/15.4/nashorn-core-15.4.jar
+	@curl -L -o ./lib/asm.jar https://repo.maven.apache.org/maven2/org/ow2/asm/asm/7.3.1/asm-7.3.1.jar
+	@curl -L -o ./lib/asm-util.jar https://repo.maven.apache.org/maven2/org/ow2/asm/asm-util/7.3.1/asm-util-7.3.1.jar
+	@curl -L -o ./lib/asm-commons.jar https://repo.maven.apache.org/maven2/org/ow2/asm/asm-commons/7.3.1/asm-commons-7.3.1.jar
+	@curl -L -o ./lib/asm-tree.jar https://repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/7.3.1/asm-tree-7.3.1.jar
+	@curl -L -o ./lib/asm-analysis.jar https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/7.3.1/asm-analysis-7.3.1.jar
+	@echo "✅ Dependencies installed."
+
 build:
 	@echo "🏗️ Building Docker image: $(IMAGE_NAME):$(IMAGE_TAG)..."
 	@docker build -t $(IMAGE_NAME):$(IMAGE_TAG) .
@@ -38,9 +52,23 @@ stop:
 	@echo "🛑 Stopping container: $(CONTAINER_NAME)..."
 	@docker stop $(CONTAINER_NAME) || true
 
+run-local:
+	@java -cp ./release/app.jar:./projects/tmp:./lib/* ch.technokrat.gecko.GeckoSim
+
 export:
-	@echo "📦 Exporting build artifacts to ./dist..."
-	@DOCKER_BUILDKIT=1 docker build --target build --output type=local,dest=./dist .
+	@echo "📦 Generating standalone JAR for native execution..."
+	@mkdir -p ./release
+	# 1. Build the image for the 'build' stage and tag it temporarily
+	@docker build --target build -t $(IMAGE_NAME)-build-temp . > /dev/null
+	# 2. Create a temporary container from the build stage image
+	@docker create --name artifact-extractor $(IMAGE_NAME)-build-temp > /dev/null
+	# 3. Copy the specific JAR file out of the container to the host's ./release folder
+	@docker cp artifact-extractor:/app/target/app.jar ./release/
+	# 4. Clean up: remove the temporary container and image
+	@docker rm artifact-extractor > /dev/null
+	@docker rmi $(IMAGE_NAME)-build-temp > /dev/null
+	@echo "✅ JAR successfully extracted to ./release/app.jar"
+	@echo "Note: To run natively on Ubuntu, ensure OpenJDK 17 or higher is installed."
 
 ls:
 	@echo "--- 📂 Listing files in $(CONTAINER_PROJECT_DIR) (inside container $(CONTAINER_NAME)) ---"

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>13</maven.compiler.source>
+    <maven.compiler.target>13</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -28,9 +28,9 @@
     </dependency>
     <!-- https://mvnrepository.com/artifact/de.sciss/syntaxpane -->
     <dependency>
-        <groupId>de.sciss</groupId>
-        <artifactId>syntaxpane</artifactId>
-        <version>1.2.0</version>
+      <groupId>de.sciss</groupId>
+      <artifactId>syntaxpane</artifactId>
+      <version>1.2.0</version>
     </dependency>
     <dependency>
       <groupId>edu.emory.mathcs</groupId>
@@ -52,17 +52,27 @@
     <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-svggen</artifactId>
-        <version>1.7</version>
+        <version>1.17</version>
     </dependency>
     <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-dom</artifactId>
-        <version>1.7</version>
+        <version>1.17</version>
     </dependency>
     <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-transcoder</artifactId>
-        <version>1.7</version>
+        <version>1.17</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-swing</artifactId>
+      <version>1.17</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>fop</artifactId>
+      <version>2.8</version>
     </dependency>
     <dependency>
       <groupId>org.netbeans.external</groupId>
@@ -77,83 +87,70 @@
   </dependencies>
 
   <build>
-    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
-      <plugins>
-        <plugin>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>3.1.0</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.7.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.0.0</version>
-        </plugin>
-        <!-- see http://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
-        <plugin>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>3.0.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
-          <configuration>
-            <trimStackTrace>false</trimStackTrace>
-          </configuration>
-        </plugin>
-        <plugin>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>3.0.2</version>
-          <configuration>
-            <archive>
-              <manifest>
-                <addClasspath>true</addClasspath>
-                <mainClass>ch.technokrat.gecko.GeckoSim</mainClass>
-              </manifest>
-            </archive>
-          </configuration>
-        </plugin>
-        <plugin>
-          <artifactId>maven-install-plugin</artifactId>
-          <version>2.5.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.1.1</version>
-          <configuration>
-            <descriptorRefs>
-              <descriptorRef>jar-with-dependencies</descriptorRef>
-            </descriptorRefs>
-            <archive>
-              <manifest>
-                <addClasspath>true</addClasspath>
-                <mainClass>ch.technokrat.gecko.GeckoSim</mainClass>
-              </manifest>
-            </archive>
-          </configuration>
-          <executions>
-            <execution>
-              <id>make-assembly</id> <!-- this is used for inheritance merges -->
-              <phase>package</phase> <!-- bind to the packaging phase -->
-              <goals>
-                <goal>single</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
+    <finalName>app</finalName>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+          <compilerArgs>
+            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+                <relocations>
+                    <relocation>
+                        <pattern>gecko.geckocircuits</pattern>
+                        <shadedPattern>ch.technokrat.gecko.geckocircuits</shadedPattern>
+                    </relocation>
+                </relocations>
+                <transformers>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                        <mainClass>ch.technokrat.gecko.GeckoSim</mainClass>
+                    </transformer>
+                </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.1.0</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.1</version>
+        <configuration>
+          <trimStackTrace>false</trimStackTrace>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+      </plugin>
+    </plugins>
+    </build>
 
   <reporting>
     <plugins>
@@ -162,4 +159,5 @@
       </plugin>
     </plugins>
   </reporting>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -110,12 +110,6 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-                <relocations>
-                    <relocation>
-                        <pattern>gecko.geckocircuits</pattern>
-                        <shadedPattern>ch.technokrat.gecko.geckocircuits</shadedPattern>
-                    </relocation>
-                </relocations>
                 <transformers>
                     <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                         <mainClass>ch.technokrat.gecko.GeckoSim</mainClass>

--- a/src/main/java/ch/technokrat/gecko/geckoscript/SimulationAccess.java
+++ b/src/main/java/ch/technokrat/gecko/geckoscript/SimulationAccess.java
@@ -43,13 +43,7 @@ public class SimulationAccess implements GeckoFileable {
         se = SchematischeEingabe2.Singleton;
         mainWindow = fenster;
         assert mainWindow != null;
-        try {
-            scriptwindow = new ScriptWindow(this);
-
-        } catch (Throwable ex) {
-            System.out.println("Could not find editor library jsyntaxpane.jar. Scripting tool disabled.");
-            // ex.printStackTrace();
-        }
+        scriptwindow = new ScriptWindow(this);
 
     }
 


### PR DESCRIPTION
This is an improvement from the previous PR.

I made adjustments to the `Makefile` to support Ubuntu 24.04.

1. **Added `install` target:** installing `openjdk-17-jdk` and the required GUI libraries.

2. **Resolved Java incompatibility:** The app crashed on modern Java because the Nashorn Javascript engine was removed (in JDK 15). I added the `install` target to download the standalone `nashorn-core.jar` and its `asm` dependencies into a `./lib` folder.

3. **Added `run-local` target:** Added the new `./lib` JARs to the classpath.

Now the project can be run directly on the host OS (`make run-local`) or within the Docker container (`make run`).

Tested with an old simulation file, and everything is working.